### PR TITLE
Fix issues 6 to 8

### DIFF
--- a/src/zcl_soar_manager.clas.locals_imp.abap
+++ b/src/zcl_soar_manager.clas.locals_imp.abap
@@ -1,0 +1,74 @@
+*"* use this source file for the definition and implementation of
+*"* local helper classes, interface definitions and type
+*"* declarations
+
+CLASS lcl_manager_w_dynamic_provider DEFINITION
+  FINAL
+  CREATE PRIVATE .
+
+  PUBLIC SECTION.
+
+    INTERFACES zif_soar_provider.
+
+    CLASS-METHODS create
+      IMPORTING
+        srp_id               TYPE csequence
+        provider_class_name  TYPE csequence
+        provider_method_name TYPE csequence
+      RETURNING
+        VALUE(result)        TYPE REF TO object
+      RAISING
+        cx_static_check
+        cx_dynamic_check.
+
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+
+    TYPES:
+      BEGIN OF ty_dynamic_provider,
+        class_name  TYPE seoclsname,
+        method_name TYPE seomtdname,
+      END OF ty_dynamic_provider.
+
+    DATA dynamic_provider TYPE ty_dynamic_provider.
+    DATA provider TYPE REF TO zif_soar_provider.
+
+ENDCLASS.
+
+
+
+CLASS lcl_manager_w_dynamic_provider IMPLEMENTATION.
+
+  METHOD create.
+
+    DATA(provider) = NEW lcl_manager_w_dynamic_provider( ).
+
+    provider->dynamic_provider = VALUE #(
+        class_name  = provider_class_name
+        method_name = provider_method_name ).
+
+    result = zcl_soar_manager=>zif_soar_manager~create(
+                    srp_id   = srp_id
+                    provider = provider ).
+
+  ENDMETHOD.
+
+
+  METHOD zif_soar_provider~get_abap_source_code.
+
+    TRY.
+        DATA(abap_code) = VALUE string_table( ).
+
+        CALL METHOD (dynamic_provider-class_name)=>(dynamic_provider-method_name)
+          RECEIVING
+            result = abap_code.
+
+        result = abap_code.
+
+      CATCH cx_root INTO DATA(error).
+        RAISE EXCEPTION TYPE zcx_soar EXPORTING previous = error.
+    ENDTRY.
+
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/zcx_soar.clas.abap
+++ b/src/zcx_soar.clas.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 CLASS zcx_soar DEFINITION
   INHERITING FROM cx_static_check
   PUBLIC

--- a/src/zif_soar_demo.intf.abap
+++ b/src/zif_soar_demo.intf.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 INTERFACE zif_soar_demo
   PUBLIC .
   CLASS-METHODS create

--- a/src/zif_soar_manager.intf.abap
+++ b/src/zif_soar_manager.intf.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 INTERFACE zif_soar_manager
   PUBLIC .
 

--- a/src/zif_soar_manager_test.intf.abap
+++ b/src/zif_soar_manager_test.intf.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 INTERFACE zif_soar_manager_test
   PUBLIC .
 

--- a/src/zif_soar_provider.intf.abap
+++ b/src/zif_soar_provider.intf.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 INTERFACE zif_soar_provider
   PUBLIC .
 

--- a/src/zsoar_demo.prog.abap
+++ b/src/zsoar_demo.prog.abap
@@ -1,8 +1,32 @@
-*&---------------------------------------------------------------------*
-*& Report zsoar_demo
-*&---------------------------------------------------------------------*
-*&
-*&---------------------------------------------------------------------*
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 REPORT zsoar_demo.
 
 CLASS lcl_soar_provider DEFINITION

--- a/src/zsoar_demo_inhousedev_form.prog.abap
+++ b/src/zsoar_demo_inhousedev_form.prog.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 PROGRAM zsoar_demo_inhousedev_form REDUCED FUNCTIONALITY.
 INCLUDE zsoar_srpoo_forms.
 CLASS lcl_soar_demo DEFINITION.

--- a/src/zsoar_demo_inhousedev_full_oo.prog.abap
+++ b/src/zsoar_demo_inhousedev_full_oo.prog.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 PROGRAM REDUCED FUNCTIONALITY.
 CLASS lcl_soar_demo DEFINITION.
   PUBLIC SECTION.

--- a/src/zsoar_manager_test_inhousedev.prog.abap
+++ b/src/zsoar_manager_test_inhousedev.prog.abap
@@ -1,3 +1,32 @@
+**********************************************************************
+*
+* https://github.com/sandraros/abap-soar
+*
+**********************************************************************
+*
+* MIT License
+*
+* Copyright (c) 2023 sandraros
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+**********************************************************************
 PROGRAM zsoar_manager_test_inhousedev REDUCED FUNCTIONALITY.
 INCLUDE zsoar_srpoo_forms.
 CLASS lcl_test DEFINITION.


### PR DESCRIPTION
Fix #8 - Add MIT License notice at top of files documentation
Fix #7 - Make it easier to instantiate the manager with dynamic reference enhancement
Fix #6 - Uncaught CX_SY exceptions on GENERATE SUBROUTINE POOL